### PR TITLE
Start child with `execve` without forking (fix #1)

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,2 @@
+[build]
+target = "x86_64-unknown-linux-musl"

--- a/Cargo.nix
+++ b/Cargo.nix
@@ -15,10 +15,16 @@ rec {
       authors = [ "Ente <ducksource@duckpond.ch>" ];
       edition = "2018";
       src = exclude [ ".git" "target" ] ./.;
+      dependencies = mapFeatures features ([
+        (cratesIO.crates."exec"."${deps."kamikaze"."0.1.0"."exec"}" deps)
+      ]);
     };
     features_.kamikaze."0.1.0" = deps: f: updateFeatures f (rec {
+      exec."${deps.kamikaze."0.1.0".exec}".default = true;
       kamikaze."0.1.0".default = (f.kamikaze."0.1.0".default or true);
-    }) [];
+    }) [
+      (cratesIO.features_.exec."${deps."kamikaze"."0.1.0"."exec"}" deps)
+    ];
 
 
 # end
@@ -27,5 +33,28 @@ rec {
 
   kamikaze = crates.crates.kamikaze."0.1.0" deps;
   __all = [ (kamikaze {}) ];
-  deps.kamikaze."0.1.0" = {};
+  deps.errno."0.2.4" = {
+    errno_dragonfly = "0.1.1";
+    libc = "0.2.54";
+    winapi = "0.3.7";
+  };
+  deps.errno_dragonfly."0.1.1" = {
+    libc = "0.2.54";
+    gcc = "0.3.55";
+  };
+  deps.exec."0.3.1" = {
+    errno = "0.2.4";
+    libc = "0.2.54";
+  };
+  deps.gcc."0.3.55" = {};
+  deps.kamikaze."0.1.0" = {
+    exec = "0.3.1";
+  };
+  deps.libc."0.2.54" = {};
+  deps.winapi."0.3.7" = {
+    winapi_i686_pc_windows_gnu = "0.4.0";
+    winapi_x86_64_pc_windows_gnu = "0.4.0";
+  };
+  deps.winapi_i686_pc_windows_gnu."0.4.0" = {};
+  deps.winapi_x86_64_pc_windows_gnu."0.4.0" = {};
 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,4 @@ authors = ["Ente <ducksource@duckpond.ch>"]
 edition = "2018"
 
 [dependencies]
+exec = "0.3.1"

--- a/crates-io.list
+++ b/crates-io.list
@@ -1,0 +1,8 @@
+errno-0.2.4
+errno-dragonfly-0.1.1
+exec-0.3.1
+gcc-0.3.55
+libc-0.2.54
+winapi-0.3.7
+winapi-i686-pc-windows-gnu-0.4.0
+winapi-x86_64-pc-windows-gnu-0.4.0

--- a/crates-io.nix
+++ b/crates-io.nix
@@ -5,4 +5,216 @@ let inherit (lib.lists) fold;
 in
 rec {
 
+# errno-0.2.4
+
+  crates.errno."0.2.4" = deps: { features?(features_.errno."0.2.4" deps {}) }: buildRustCrate {
+    crateName = "errno";
+    version = "0.2.4";
+    description = "Cross-platform interface to the `errno` variable.";
+    authors = [ "Chris Wong <lambda.fairy@gmail.com>" ];
+    sha256 = "145rd8ccjsj99hxkw9g9gnak56qqxlq85hqyj35wba6j2ibxbwy2";
+    dependencies = (if kernel == "dragonfly" then mapFeatures features ([
+      (crates."errno_dragonfly"."${deps."errno"."0.2.4"."errno_dragonfly"}" deps)
+    ]) else [])
+      ++ (if (kernel == "linux" || kernel == "darwin") then mapFeatures features ([
+      (crates."libc"."${deps."errno"."0.2.4"."libc"}" deps)
+    ]) else [])
+      ++ (if kernel == "windows" then mapFeatures features ([
+      (crates."winapi"."${deps."errno"."0.2.4"."winapi"}" deps)
+    ]) else []);
+  };
+  features_.errno."0.2.4" = deps: f: updateFeatures f (rec {
+    errno."0.2.4".default = (f.errno."0.2.4".default or true);
+    errno_dragonfly."${deps.errno."0.2.4".errno_dragonfly}".default = true;
+    libc."${deps.errno."0.2.4".libc}".default = true;
+    winapi = fold recursiveUpdate {} [
+      { "${deps.errno."0.2.4".winapi}"."errhandlingapi" = true; }
+      { "${deps.errno."0.2.4".winapi}"."minwindef" = true; }
+      { "${deps.errno."0.2.4".winapi}"."ntdef" = true; }
+      { "${deps.errno."0.2.4".winapi}"."winbase" = true; }
+      { "${deps.errno."0.2.4".winapi}".default = true; }
+    ];
+  }) [
+    (features_.errno_dragonfly."${deps."errno"."0.2.4"."errno_dragonfly"}" deps)
+    (features_.libc."${deps."errno"."0.2.4"."libc"}" deps)
+    (features_.winapi."${deps."errno"."0.2.4"."winapi"}" deps)
+  ];
+
+
+# end
+# errno-dragonfly-0.1.1
+
+  crates.errno_dragonfly."0.1.1" = deps: { features?(features_.errno_dragonfly."0.1.1" deps {}) }: buildRustCrate {
+    crateName = "errno-dragonfly";
+    version = "0.1.1";
+    description = "Exposes errno functionality to stable Rust on DragonFlyBSD";
+    authors = [ "Michael Neumann <mneumann@ntecs.de>" ];
+    sha256 = "1bpnr0z3bl2zxnm7syqbgmxsj18qm8l4s1jxr7czpbhdqhgfgvcf";
+    dependencies = mapFeatures features ([
+      (crates."libc"."${deps."errno_dragonfly"."0.1.1"."libc"}" deps)
+    ]);
+
+    buildDependencies = mapFeatures features ([
+      (crates."gcc"."${deps."errno_dragonfly"."0.1.1"."gcc"}" deps)
+    ]);
+  };
+  features_.errno_dragonfly."0.1.1" = deps: f: updateFeatures f (rec {
+    errno_dragonfly."0.1.1".default = (f.errno_dragonfly."0.1.1".default or true);
+    gcc."${deps.errno_dragonfly."0.1.1".gcc}".default = true;
+    libc."${deps.errno_dragonfly."0.1.1".libc}".default = true;
+  }) [
+    (features_.libc."${deps."errno_dragonfly"."0.1.1"."libc"}" deps)
+    (features_.gcc."${deps."errno_dragonfly"."0.1.1"."gcc"}" deps)
+  ];
+
+
+# end
+# exec-0.3.1
+
+  crates.exec."0.3.1" = deps: { features?(features_.exec."0.3.1" deps {}) }: buildRustCrate {
+    crateName = "exec";
+    version = "0.3.1";
+    description = "Use the POSIX exec function to replace the running program with another";
+    authors = [ "Eric Kidd <git@randomhacks.net>" ];
+    sha256 = "0adp2bib4xh0r7kxs9m3r2jva250irxcikk8p796njpvqk7gjgah";
+    dependencies = mapFeatures features ([
+      (crates."errno"."${deps."exec"."0.3.1"."errno"}" deps)
+      (crates."libc"."${deps."exec"."0.3.1"."libc"}" deps)
+    ]);
+    features = mkFeatures (features."exec"."0.3.1" or {});
+  };
+  features_.exec."0.3.1" = deps: f: updateFeatures f (rec {
+    errno."${deps.exec."0.3.1".errno}".default = true;
+    exec."0.3.1".default = (f.exec."0.3.1".default or true);
+    libc."${deps.exec."0.3.1".libc}".default = true;
+  }) [
+    (features_.errno."${deps."exec"."0.3.1"."errno"}" deps)
+    (features_.libc."${deps."exec"."0.3.1"."libc"}" deps)
+  ];
+
+
+# end
+# gcc-0.3.55
+
+  crates.gcc."0.3.55" = deps: { features?(features_.gcc."0.3.55" deps {}) }: buildRustCrate {
+    crateName = "gcc";
+    version = "0.3.55";
+    description = "**Deprecated** crate, renamed to `cc`\n\nA build-time dependency for Cargo build scripts to assist in invoking the native\nC compiler to compile native C code into a static archive to be linked into Rust\ncode.\n";
+    authors = [ "Alex Crichton <alex@alexcrichton.com>" ];
+    sha256 = "18qxv3hjdhp7pfcvbm2hvyicpgmk7xw8aii1l7fla8cxxbcrg2nz";
+    dependencies = mapFeatures features ([
+]);
+    features = mkFeatures (features."gcc"."0.3.55" or {});
+  };
+  features_.gcc."0.3.55" = deps: f: updateFeatures f (rec {
+    gcc = fold recursiveUpdate {} [
+      { "0.3.55"."rayon" =
+        (f.gcc."0.3.55"."rayon" or false) ||
+        (f.gcc."0.3.55".parallel or false) ||
+        (gcc."0.3.55"."parallel" or false); }
+      { "0.3.55".default = (f.gcc."0.3.55".default or true); }
+    ];
+  }) [];
+
+
+# end
+# libc-0.2.54
+
+  crates.libc."0.2.54" = deps: { features?(features_.libc."0.2.54" deps {}) }: buildRustCrate {
+    crateName = "libc";
+    version = "0.2.54";
+    description = "Raw FFI bindings to platform libraries like libc.\n";
+    authors = [ "The Rust Project Developers" ];
+    sha256 = "11nrsbpmwcnfrjcds0wnicwwql3809nq6q6z00q920bdpryyaf58";
+    build = "build.rs";
+    dependencies = mapFeatures features ([
+]);
+    features = mkFeatures (features."libc"."0.2.54" or {});
+  };
+  features_.libc."0.2.54" = deps: f: updateFeatures f (rec {
+    libc = fold recursiveUpdate {} [
+      { "0.2.54"."align" =
+        (f.libc."0.2.54"."align" or false) ||
+        (f.libc."0.2.54".rustc-dep-of-std or false) ||
+        (libc."0.2.54"."rustc-dep-of-std" or false); }
+      { "0.2.54"."rustc-std-workspace-core" =
+        (f.libc."0.2.54"."rustc-std-workspace-core" or false) ||
+        (f.libc."0.2.54".rustc-dep-of-std or false) ||
+        (libc."0.2.54"."rustc-dep-of-std" or false); }
+      { "0.2.54"."use_std" =
+        (f.libc."0.2.54"."use_std" or false) ||
+        (f.libc."0.2.54".default or false) ||
+        (libc."0.2.54"."default" or false); }
+      { "0.2.54".default = (f.libc."0.2.54".default or true); }
+    ];
+  }) [];
+
+
+# end
+# winapi-0.3.7
+
+  crates.winapi."0.3.7" = deps: { features?(features_.winapi."0.3.7" deps {}) }: buildRustCrate {
+    crateName = "winapi";
+    version = "0.3.7";
+    description = "Raw FFI bindings for all of Windows API.";
+    authors = [ "Peter Atashian <retep998@gmail.com>" ];
+    sha256 = "1k51gfkp0zqw7nj07y443mscs46icmdhld442s2073niap0kkdr8";
+    build = "build.rs";
+    dependencies = (if kernel == "i686-pc-windows-gnu" then mapFeatures features ([
+      (crates."winapi_i686_pc_windows_gnu"."${deps."winapi"."0.3.7"."winapi_i686_pc_windows_gnu"}" deps)
+    ]) else [])
+      ++ (if kernel == "x86_64-pc-windows-gnu" then mapFeatures features ([
+      (crates."winapi_x86_64_pc_windows_gnu"."${deps."winapi"."0.3.7"."winapi_x86_64_pc_windows_gnu"}" deps)
+    ]) else []);
+    features = mkFeatures (features."winapi"."0.3.7" or {});
+  };
+  features_.winapi."0.3.7" = deps: f: updateFeatures f (rec {
+    winapi = fold recursiveUpdate {} [
+      { "0.3.7"."impl-debug" =
+        (f.winapi."0.3.7"."impl-debug" or false) ||
+        (f.winapi."0.3.7".debug or false) ||
+        (winapi."0.3.7"."debug" or false); }
+      { "0.3.7".default = (f.winapi."0.3.7".default or true); }
+    ];
+    winapi_i686_pc_windows_gnu."${deps.winapi."0.3.7".winapi_i686_pc_windows_gnu}".default = true;
+    winapi_x86_64_pc_windows_gnu."${deps.winapi."0.3.7".winapi_x86_64_pc_windows_gnu}".default = true;
+  }) [
+    (features_.winapi_i686_pc_windows_gnu."${deps."winapi"."0.3.7"."winapi_i686_pc_windows_gnu"}" deps)
+    (features_.winapi_x86_64_pc_windows_gnu."${deps."winapi"."0.3.7"."winapi_x86_64_pc_windows_gnu"}" deps)
+  ];
+
+
+# end
+# winapi-i686-pc-windows-gnu-0.4.0
+
+  crates.winapi_i686_pc_windows_gnu."0.4.0" = deps: { features?(features_.winapi_i686_pc_windows_gnu."0.4.0" deps {}) }: buildRustCrate {
+    crateName = "winapi-i686-pc-windows-gnu";
+    version = "0.4.0";
+    description = "Import libraries for the i686-pc-windows-gnu target. Please don't use this crate directly, depend on winapi instead.";
+    authors = [ "Peter Atashian <retep998@gmail.com>" ];
+    sha256 = "05ihkij18r4gamjpxj4gra24514can762imjzlmak5wlzidplzrp";
+    build = "build.rs";
+  };
+  features_.winapi_i686_pc_windows_gnu."0.4.0" = deps: f: updateFeatures f (rec {
+    winapi_i686_pc_windows_gnu."0.4.0".default = (f.winapi_i686_pc_windows_gnu."0.4.0".default or true);
+  }) [];
+
+
+# end
+# winapi-x86_64-pc-windows-gnu-0.4.0
+
+  crates.winapi_x86_64_pc_windows_gnu."0.4.0" = deps: { features?(features_.winapi_x86_64_pc_windows_gnu."0.4.0" deps {}) }: buildRustCrate {
+    crateName = "winapi-x86_64-pc-windows-gnu";
+    version = "0.4.0";
+    description = "Import libraries for the x86_64-pc-windows-gnu target. Please don't use this crate directly, depend on winapi instead.";
+    authors = [ "Peter Atashian <retep998@gmail.com>" ];
+    sha256 = "0n1ylmlsb8yg1v583i4xy0qmqg42275flvbc51hdqjjfjcl9vlbj";
+    build = "build.rs";
+  };
+  features_.winapi_x86_64_pc_windows_gnu."0.4.0" = deps: f: updateFeatures f (rec {
+    winapi_x86_64_pc_windows_gnu."0.4.0".default = (f.winapi_x86_64_pc_windows_gnu."0.4.0".default or true);
+  }) [];
+
+
+# end
 }

--- a/default.nix
+++ b/default.nix
@@ -1,9 +1,37 @@
 with import <nixpkgs> {};
+let
+  rust = (import ./rust.nix);
+  extraRustcOpts = [ "--target x86_64-unknown-linux-musl" ];
+in
 ((import ./Cargo.nix).kamikaze {}).override {
-  rust = (import ./shell.nix).rust;
+  rust = rust;
   crateOverrides = defaultCrateOverrides // {
     kamikaze = attrs: {
-      extraRustcOpts = [ "--target x86_64-unknown-linux-musl" ];
+      extraRustcOpts = extraRustcOpts;
+    };
+    errno = attrs: {
+      extraRustcOpts = extraRustcOpts;
+    };
+    errno-dragonfly = attrs: {
+      extraRustcOpts = extraRustcOpts;
+    };
+    exec = attrs: {
+      extraRustcOpts = extraRustcOpts;
+    };
+    gcc = attrs: {
+      extraRustcOpts = extraRustcOpts;
+    };
+    libc = attrs: {
+      extraRustcOpts = extraRustcOpts;
+    };
+    winapi = attrs: {
+      extraRustcOpts = extraRustcOpts;
+    };
+    winapi-i686-pc-windows-gnu = attrs: {
+      extraRustcOpts = extraRustcOpts;
+    };
+    winapi-x86_64-pc-windows-gnu = attrs: {
+      extraRustcOpts = extraRustcOpts;
     };
   };
 }

--- a/rust.nix
+++ b/rust.nix
@@ -1,0 +1,11 @@
+with import <nixpkgs> {};
+let
+  src = fetchFromGitHub {
+    owner = "mozilla";
+    repo = "nixpkgs-mozilla";
+    rev = "50bae918794d3c283aeb335b209efd71e75e3954";
+    sha256 = "07b7hgq5awhddcii88y43d38lncqq9c8b2px4p93r5l7z0phv89d";
+  };
+  moz_rust = import "${src.out}/rust-overlay.nix" pkgs pkgs;
+in
+  moz_rust.rustChannelOfTargets "nightly" null ["x86_64-unknown-linux-musl"]

--- a/shell.nix
+++ b/shell.nix
@@ -1,22 +1,11 @@
 with import <nixpkgs> {};
-let
-  src = fetchFromGitHub {
-    owner = "mozilla";
-    repo = "nixpkgs-mozilla";
-    rev = "50bae918794d3c283aeb335b209efd71e75e3954";
-    sha256 = "07b7hgq5awhddcii88y43d38lncqq9c8b2px4p93r5l7z0phv89d";
-  };
-  moz_rust = import "${src.out}/rust-overlay.nix" pkgs pkgs;
-  rust-musl = moz_rust.rustChannelOfTargets "nightly" null ["x86_64-unknown-linux-musl"];
-in
 stdenv.mkDerivation {
   name = "kamikaze";
   authors = [ "Ente <ducksource@duckpond.ch>" ];
 
-  rust = rust-musl;
-  buildInputs = [
+  nativeBuildInputs = [
     #latest.rustChannels.nightly.rust
-    rust-musl
+    (import ./rust.nix)
   ];
 
   # Set Environment Variables

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,13 @@
+extern crate exec;
+
 use std::env;
 
 use std::fs;
 
-use std::process::{Command, exit};
+use std::process::exit;
 
 fn usage() {
     println!("usage: kamikaze <command> <arguments>");
-    exit(1);
 }
 
 fn main() {
@@ -22,18 +23,12 @@ fn main() {
         1 => usage(),
         _ => {
             args.remove(0);
-            let mut child = Command::new(args.remove(0))
+            let err = exec::Command::new(args.remove(0))
                 .args(&args)
-                .spawn()
-                .expect("failed to execute process");
-            exit(
-                child
-                    .wait()
-                    .expect("wait failed")
-                        .code().unwrap()
-            );
+                .exec();
+            println!("Error: {}", err);
         },
     }
-
+    exit(1);
 }
 


### PR DESCRIPTION
Instead of spawning a process (fork & execve) we replace the `kamikaze` process with the new process directly.